### PR TITLE
use raspberrypi3-debian image to allow armv7 and nodejs 12

### DIFF
--- a/azure-pipelines.pr.yml
+++ b/azure-pipelines.pr.yml
@@ -26,7 +26,7 @@ jobs:
     - script: |
         docker version
         docker run --rm --privileged multiarch/qemu-user-static:register --reset
-        docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name) --platform arm
+        docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name)
         docker images
         docker inspect $(container.name)
       displayName: 'Build $(stage.name) Container'

--- a/azure-pipelines.pr.yml
+++ b/azure-pipelines.pr.yml
@@ -25,5 +25,7 @@ jobs:
     steps:
     - script: |
         docker run --rm --privileged multiarch/qemu-user-static:register --reset
-        docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name)
+        docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name) --platform arm
+        docker images
+        docker inspect $(container.name)
       displayName: 'Build $(stage.name) Container'

--- a/azure-pipelines.pr.yml
+++ b/azure-pipelines.pr.yml
@@ -8,7 +8,7 @@ pr:
 jobs:
   - job: Build
     pool:
-      vmImage: 'Ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     strategy:
       matrix:
         Janus:
@@ -24,6 +24,7 @@ jobs:
 
     steps:
     - script: |
+        docker --version
         docker run --rm --privileged multiarch/qemu-user-static:register --reset
         docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name) --platform arm
         docker images

--- a/azure-pipelines.pr.yml
+++ b/azure-pipelines.pr.yml
@@ -24,7 +24,13 @@ jobs:
 
     steps:
     - script: |
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        sudo apt-get update
+        sudo apt-get install docker-ce
         docker --version
+      displayName: 'Update docker'
+    - script: |
         docker run --rm --privileged multiarch/qemu-user-static:register --reset
         docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name) --platform arm
         docker images

--- a/azure-pipelines.pr.yml
+++ b/azure-pipelines.pr.yml
@@ -24,13 +24,7 @@ jobs:
 
     steps:
     - script: |
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-        sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-        sudo apt-get update
-        sudo apt-get install docker-ce
-        docker --version
-      displayName: 'Update docker'
-    - script: |
+        docker version
         docker run --rm --privileged multiarch/qemu-user-static:register --reset
         docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name) --platform arm
         docker images

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       - script: |
           docker version
           docker run --rm --privileged multiarch/qemu-user-static:register --reset
-          docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name) --platform arm
+          docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name)
           docker images
           docker inspect $(container.name)
         displayName: 'Build $(stage.name) Container'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
       maxParallel: 3
     steps:
       - script: |
-          docker --version
+          docker version
           docker run --rm --privileged multiarch/qemu-user-static:register --reset
           docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name) --platform arm
           docker images

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
 jobs:
   - job: Build
     pool:
-      vmImage: 'Ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     strategy:
       matrix:
         Janus:
@@ -31,6 +31,7 @@ jobs:
       maxParallel: 3
     steps:
       - script: |
+          docker --version
           docker run --rm --privileged multiarch/qemu-user-static:register --reset
           docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name) --platform arm
           docker images

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,9 @@ jobs:
     steps:
       - script: |
           docker run --rm --privileged multiarch/qemu-user-static:register --reset
-          docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name)
+          docker build . -f docker/$(stage.name)/Dockerfile -t $(container.name) --platform arm
+          docker images
+          docker inspect $(container.name)
         displayName: 'Build $(stage.name) Container'
 
       - script: |

--- a/docker/fruitnanny/Dockerfile
+++ b/docker/fruitnanny/Dockerfile
@@ -1,10 +1,9 @@
-FROM balenalib/rpi-raspbian:buster
+FROM node:lts-buster
 
 RUN buildDeps="build-essential python-dev python3-dev python-setuptools python3-setuptools" \
     && echo 'APT::Install-Recommends "false";' >/etc/apt/apt.conf.d/00recommends \
     && echo 'APT::Install-Suggests "false";' >>/etc/apt/apt.conf.d/00recommends \
     && apt-get update \
-    && apt-get install -y --no-install-recommends nodejs npm \
     && apt-get install -y python-pip python3-pip dos2unix \
     && apt-get install -y $buildDeps \
     && pip install wheel && pip install --install-option="--force-pi2" Adafruit-DHT \

--- a/docker/fruitnanny/Dockerfile
+++ b/docker/fruitnanny/Dockerfile
@@ -1,9 +1,10 @@
-FROM arm32v7/node:12.13.0-buster
+FROM balenalib/rpi-raspbian:buster
 
 RUN buildDeps="build-essential python-dev python3-dev python-setuptools python3-setuptools" \
     && echo 'APT::Install-Recommends "false";' >/etc/apt/apt.conf.d/00recommends \
     && echo 'APT::Install-Suggests "false";' >>/etc/apt/apt.conf.d/00recommends \
     && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs npm \
     && apt-get install -y python-pip python3-pip dos2unix \
     && apt-get install -y $buildDeps \
     && pip install wheel && pip install --install-option="--force-pi2" Adafruit-DHT \

--- a/docker/fruitnanny/Dockerfile
+++ b/docker/fruitnanny/Dockerfile
@@ -1,4 +1,18 @@
-FROM node:lts-buster
+FROM balenalib/rpi-raspbian:buster
+
+ENV NODE_VERSION 12.13.0
+
+RUN buildDeps="curl xz-utils" \
+	&& set -x \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv6l.tar.xz" \
+	&& tar -xJf "node-v$NODE_VERSION-linux-armv6l.tar.xz" -C /usr/local --strip-components=1  \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get clean \
+	&& rm "node-v$NODE_VERSION-linux-armv6l.tar.xz" \
+    && rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN buildDeps="build-essential python-dev python3-dev python-setuptools python3-setuptools" \
     && echo 'APT::Install-Recommends "false";' >/etc/apt/apt.conf.d/00recommends \

--- a/docker/fruitnanny/Dockerfile
+++ b/docker/fruitnanny/Dockerfile
@@ -5,12 +5,12 @@ ENV NODE_VERSION 12.13.0
 RUN buildDeps="curl xz-utils" \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
-	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv6l.tar.xz" \
-	&& tar -xJf "node-v$NODE_VERSION-linux-armv6l.tar.xz" -C /usr/local --strip-components=1  \
+	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7l.tar.xz" \
+	&& tar -xJf "node-v$NODE_VERSION-linux-armv7l.tar.xz" -C /usr/local --strip-components=1  \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& apt-get clean \
-	&& rm "node-v$NODE_VERSION-linux-armv6l.tar.xz" \
+	&& rm "node-v$NODE_VERSION-linux-armv7l.tar.xz" \
     && rm -rf /tmp/* \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/fruitnanny/Dockerfile
+++ b/docker/fruitnanny/Dockerfile
@@ -5,7 +5,7 @@ ENV NODE_VERSION 12.13.0
 RUN buildDeps="curl xz-utils" \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
-	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7l.tar.xz" \
+	&& curl -SLOk "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7l.tar.xz" \
 	&& tar -xJf "node-v$NODE_VERSION-linux-armv7l.tar.xz" -C /usr/local --strip-components=1  \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/docker/fruitnanny/Dockerfile
+++ b/docker/fruitnanny/Dockerfile
@@ -1,18 +1,4 @@
-FROM balenalib/rpi-raspbian:buster
-
-ENV NODE_VERSION 12.13.0
-
-RUN buildDeps="curl xz-utils" \
-	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
-	&& curl -SLOk "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7l.tar.xz" \
-	&& tar -xJf "node-v$NODE_VERSION-linux-armv7l.tar.xz" -C /usr/local --strip-components=1  \
-    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& apt-get clean \
-	&& rm "node-v$NODE_VERSION-linux-armv7l.tar.xz" \
-    && rm -rf /tmp/* \
-    && rm -rf /var/lib/apt/lists/*
+FROM balenalib/raspberrypi3-debian-node:12.11-buster
 
 RUN buildDeps="build-essential python-dev python3-dev python-setuptools python3-setuptools" \
     && echo 'APT::Install-Recommends "false";' >/etc/apt/apt.conf.d/00recommends \

--- a/docker/fruitnanny/Dockerfile
+++ b/docker/fruitnanny/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-buster
+FROM arm32v7/node:12.13.0-buster
 
 RUN buildDeps="build-essential python-dev python3-dev python-setuptools python3-setuptools" \
     && echo 'APT::Install-Recommends "false";' >/etc/apt/apt.conf.d/00recommends \

--- a/docker/gstreamer/Dockerfile
+++ b/docker/gstreamer/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/rpi-raspbian:buster
+FROM balenalib/raspberrypi3-debian:buster
 
 RUN echo 'APT::Install-Recommends "false";' >/etc/apt/apt.conf.d/00recommends \
     && echo 'APT::Install-Suggests "false";' >>/etc/apt/apt.conf.d/00recommends \

--- a/docker/janus/Dockerfile
+++ b/docker/janus/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/rpi-raspbian:buster
+FROM balenalib/raspberrypi3-debian
 
 RUN echo 'APT::Install-Recommends "false";' >/etc/apt/apt.conf.d/00recommends \
     && echo 'APT::Install-Suggests "false";' >>/etc/apt/apt.conf.d/00recommends \


### PR DESCRIPTION
* Switch to raspberrypi3-debian based images as they contain armv7 kernel. This fixes fruitnanny-app container with node 12 (requires armv7l)
* Update CI image to ubuntu 18:04